### PR TITLE
Add allocator and state stuff

### DIFF
--- a/exefs/main.xml
+++ b/exefs/main.xml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52f1a9c56e94449d7e29391c9d18411af4922162d9e3e9f7c6daf84ec99d5b6a
-size 136060372
+oid sha256:72f8af3bdeb37adf9fb6d65b23e00d291c5e1f60fb08114524513595ade0ab59
+size 136916512


### PR DESCRIPTION
This pull request makes changes to the documentation of the following code files for The Legend of Zelda: Skyward Sword HD:

* `main`

This pull request makes the following changes (give as much detail as you can):

* Adds documentation for the `ACTOR_ALLOCATOR_DEFINITIONS`
* Ports documentation of the `ActorState` related structs to HD
  * Added `ActorState`, `StateChecker`, `StateFactory`, `StateHolder`, `StateMethod`, and `StateMgr` related structs
  * Added `ActorState` and `StateMethod` function definitions
  * Added documentation of states to the `dAcOsmoke` and `GameReloader` actors
* Renamed `RELOADER_PTR` to `GAME_RELOADER_PTR` (same for all functions defined as `Reloader::*`)
* Added documentation for `GameReloader` and `TitleGameReloader`
* Add struct definition for `ObjnMgr`
* Added documentation for `dAcOTimeBoat`

[x] I confirm that the exported XML file(s) in this pull request **do not** include the `Memory Contents` of their respective code files.
